### PR TITLE
Compatibility with groovy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-#Rundeck Salt-Step Plugin
+Rundeck Salt-Step Plugin
 =========================
 
-##Description
+## Description
 
 A Rundeck <a href="http://rundeck.org/docs/developer/workflow-step-plugin-development.html#workflow-node-step-plugin">NodeStepPlugin</a> that allows Rundeck to delegate tasks to a Salt master by executing the request over <a href="https://github.com/saltstack/salt-api">salt-api</a>.
 
-##Build / Deploy
+## Build / Deploy
 
 - To build the project from source, issue: `./gradlew clean build`
 - The resulting jar files can be found under `build/libs`. 
@@ -13,11 +13,11 @@ A Rundeck <a href="http://rundeck.org/docs/developer/workflow-step-plugin-develo
 - Restart Rundeck
 - You should now have an additional "salt remote" option when configuring jobs
 
-##Configuration
+## Configuration
 
 - Rundeck node resource IDs *MUST* match salt minion IDs
 
-##Usage
+## Usage
 
 The following job-level params must be configured to provide authentication input fields:
 
@@ -27,7 +27,7 @@ The following job-level params must be configured to provide authentication inpu
 Additionally:
 - Workflow configuration must be set to dispatch to nodes.
 
-###Remote execution over salt-api
+### Remote execution over salt-api
 
 *NOTE: This plugin leverages salt-api, which requires its own additional setup. For more information on how to setup salt-api please refer to its documentation which can be found <a href="http://salt-api.readthedocs.org/en/latest/">here</a>.* 
 
@@ -41,18 +41,17 @@ This plugin requires three properties that need to be configured for each step:
 - `SALT_API_VERSION` (optional): The expected version of salt-api. Defaults to latest if left blank.
 
 
-##Troubleshooting
+## Troubleshooting
 
 - Ensure that your salt-api setup is fully functional before attempting to execute jobs with this plugin
 - Set the job output level to `debug` to print the raw JSON data and returned output
 - Ensure the API endpoint is correct
 -- http vs https
 
-##Setting up salt return response parsers
-===================
+## Setting up salt return response parsers
 This plugin interacts with salt and salt-api. By default, it requests JSON payloads. YAML configuratio​n files are used to determine how it should parse the output and behave with respect to exit codes, standard output, and standard error.
 
-###YAML Configuration File Format
+### YAML Configuration File Format
 ```
 handlerMappings:
   <salt module>[.<salt function>]: <java object implementing org.rundeck.plugin.salt.output.SaltReturnHandler>
@@ -62,30 +61,30 @@ Salt-step is configured in two locations:
 * ```src/main/resources/defaultReturners.yaml```
 * `​rundeck-​config.​properties`: The `_saltStep.​return​Handlers_` property accepts a comma separated list of additional configuratio​n files
 
-##Developer Guidelines
+## Developer Guidelines
 
 Thanks for contributing to the project!
 
-###Code style
+### Code style
 * Same line braces.
 * 4 spaces for tabs.
 * Clarity over brevity.
 * When in doubt, follow what's already there.
 
-###Javadocs
+### Javadocs
 * At the very minimum, please ensure that class-level and method-level javadocs are present.
 
-###Unit tests
+### Unit tests
 * While we don't expect 100% coverage, we do expect repeatable, automated tests.
 * Include unit tests that confirm that your change performs as expected (e.g. new feature or bug fix).
 
-###Before submitting a pull request
+### Before submitting a pull request
 * Merge the latest master branch before submitting a pull request.
 * Perform a build (`./gradlew clean build`) and confirm that all tests are passing.
 * Ensure that all documentation (e.g. `README.md` or other supporting links) is updated.
 * Rebase changes into as few commits as makes sense.
 * Ensure that all commit messages accurately describe the changes.
 
-###​Submitting a pull request
+### Submitting a pull request
 * Submit a pull request to the master branch of this project.
 * Ensure that the pull request has a clear description of the included changes.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 0.3
+version = 0.3.1
 rundeckPluginVersion = 1.1
 
 mavenCentralUrl = http://repo1.maven.org/maven2

--- a/src/main/java/org/rundeck/plugin/salt/output/SaltReturnHandlerRegistry.java
+++ b/src/main/java/org/rundeck/plugin/salt/output/SaltReturnHandlerRegistry.java
@@ -136,7 +136,15 @@ public class SaltReturnHandlerRegistry {
     }
 
     protected void configureFromFile(String file) throws FileNotFoundException, IOException {
-        FileInputStream fis = new FileInputStream(new File(file));
+        File f = new File(file.trim().replaceAll("^\"|\"$",""));
+        if(!f.exists()){
+            throw new FileNotFoundException(java.lang.String.format("File %s not found. Current dir: %s", file, new File("").getAbsolutePath()));
+        }
+        if(!f.canRead() || !f.canWrite()){
+            throw new FileNotFoundException("Not enough permission");
+        }
+
+        FileInputStream fis = new FileInputStream(f);
         try {
             configureFromInputStream(fis);
         } finally {


### PR DESCRIPTION
## Problem
Rundeck supports groovy settings and normal java properties settings: http://rundeck.org/docs/administration/configuration-file-reference.html#groovy-config-format

In groovy format, the properties is surrounded by double quote. So when we settings `_saltStep.​return​Handlers_` for additional configuration file, the plugin cannot open the file.

## Solution
If the file string surrounded by double quotes, we remove it.

## Works
* Fix some syntax in README.md
* Remove surrounded double quotes
