### PR TITLE
RUN-4569 Mitigate Jackson CVE-2026-54512/54513

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 gson = "2.10.1"
 commonsValidator = "1.10.0"
-springContext = "6.2.11"
+springContext = "6.2.19"
 httpclient = "4.5.14"
 commonsIo = "2.17.0"
 jsr305 = "3.0.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,8 +10,8 @@ commonsLang3 = "3.20.0"
 javaxAnnotation = "1.3.2"
 junit = "4.13.2"
 mockito = "5.14.2"
-rundeckCore = "6.0.0-alpha1-20260407"
-axionRelease = "1.18.17"
+rundeckCore = "6.1.0-SNAPSHOT"
+axionRelease = "1.21.2"
 nexusPublish = "2.0.0"
 
 [libraries]


### PR DESCRIPTION
## Summary
- Bump `rundeck-core` to `6.1.0-SNAPSHOT`, which pulls patched `jackson-databind` 2.22.0 transitively, mitigating CVE-2026-54512 / CVE-2026-54513.
- Standardize the axion-release plugin to 1.21.2.

## Test plan
- [x] `rundeck-core:6.1.0-SNAPSHOT` and `jackson-databind:2.22.0` resolve on compileClasspath (verified locally).
- [ ] CI build and Snyk scan pass on the branch.